### PR TITLE
Fix/plugin v1 address bugs

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "altly-plugin-react-app",
   "private": true,
-  "version": "1.1.3",
+  "version": "1.1.4",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/app/package.json
+++ b/app/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "altly-plugin",
+  "name": "altly-plugin-react-app",
   "private": true,
-  "version": "1.1.2",
+  "version": "1.1.3",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/app/package.json
+++ b/app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "altly-plugin-react-app",
   "private": true,
-  "version": "1.1.4",
+  "version": "1.1.5",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/app/package.json
+++ b/app/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "altly-plugin-react-starter",
+  "name": "altly-plugin",
   "private": true,
-  "version": "0.0.0",
+  "version": "1.1.2",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/app/src/components/AppShell.jsx
+++ b/app/src/components/AppShell.jsx
@@ -1,6 +1,12 @@
-import { Fragment, useState } from 'react';
-import { Disclosure, Menu, Transition } from '@headlessui/react';
-import { Bars3Icon, BellIcon, XMarkIcon } from '@heroicons/react/24/outline';
+import { useState } from 'react';
+
+import { Disclosure } from '@headlessui/react';
+import {
+  Bars3Icon,
+  BellIcon,
+  XMarkIcon,
+} from '@heroicons/react/24/outline';
+
 import Link from './Link';
 
 const user = {
@@ -15,16 +21,17 @@ function classNames(...classes) {
 }
 
 export default function AppShell({ children }) {
+  const currentUrl = window.location.href;
   const [navigation, setNavigation] = useState([
     {
       name: 'Dashboard',
       href: 'upload.php?page=altly&screen=dashboard',
-      current: true,
+      current: currentUrl.includes('dashboard'),
     },
     {
       name: 'Settings',
       href: 'upload.php?page=altly&screen=settings',
-      current: false,
+      current: currentUrl.includes('settings'),
     },
   ]);
 

--- a/app/src/components/AppShell.jsx
+++ b/app/src/components/AppShell.jsx
@@ -63,13 +63,13 @@ export default function AppShell({ children }) {
                     <div className='flex flex-shrink-0 items-center'>
                       <img
                         className='block h-8 w-auto lg:hidden'
-                        src='https://tailwindui.com/img/logos/mark.svg?color=indigo&shade=600'
-                        alt='Your Company'
+                        src='https://altly.ai/wp-content/uploads/2024/12/a-4.svg'
+                        alt='Altly Logo'
                       />
                       <img
                         className='hidden h-8 w-auto lg:block'
-                        src='https://tailwindui.com/img/logos/mark.svg?color=indigo&shade=600'
-                        alt='Your Company'
+                        src='https://altly.ai/wp-content/uploads/2024/12/a-4.svg'
+                        alt='Altly Logo'
                       />
                     </div>
                     <div className='hidden sm:-my-px sm:ml-6 sm:flex sm:space-x-8'>

--- a/app/src/components/Form.jsx
+++ b/app/src/components/Form.jsx
@@ -4,31 +4,51 @@ export default function Form({ onSubmit, children }) {
   // State to track the form input values
   const [formData, setFormData] = useState({});
 
-  // Function to handle form input changes
-  const handleInputChange = (event) => {
-    const { name, value } = event.target;
-    setFormData({ ...formData, [name]: value });
-  };
-
   // Function to handle form submission
   const handleSubmit = (event) => {
     event.preventDefault();
-    onSubmit(formData);
+    // Collect all form data including controlled inputs
+    const allFormData = { ...formData };
+    const formElements = event.target.elements;
+
+    for (let i = 0; i < formElements.length; i++) {
+      const element = formElements[i];
+      if (element.name) {
+        allFormData[element.name] = element.value;
+      }
+    }
+
+    onSubmit(allFormData);
   };
 
-  // Function to get the current form data
-  const getFormData = () => {
-    return formData;
+  // Function to handle form input changes for uncontrolled inputs
+  const handleInputChange = (event) => {
+    const { name, value } = event.target;
+    setFormData((prev) => ({ ...prev, [name]: value }));
   };
 
   return (
     <form onSubmit={handleSubmit}>
-      {React.Children.map(children, (child) =>
-        React.cloneElement(child, {
+      {React.Children.map(children, (child) => {
+        // If it's not a valid element, return it as is
+        if (!React.isValidElement(child)) {
+          return child;
+        }
+
+        // If the child already has value and onChange props, respect those
+        if (
+          child.props.value !== undefined ||
+          child.props.onChange !== undefined
+        ) {
+          return child;
+        }
+
+        // Only add form handling for inputs without existing value/onChange
+        return React.cloneElement(child, {
           onChange: handleInputChange,
-          value: formData[child.props.name] || '', // Pass the value from formData
-        })
-      )}
+          value: formData[child.props.name] || '',
+        });
+      })}
     </form>
   );
 }

--- a/app/src/components/Heading.jsx
+++ b/app/src/components/Heading.jsx
@@ -7,7 +7,7 @@ export default function Example({ text }) {
             {text}
           </h1>
         </div>
-        <div className='mt-4 flex md:ml-4 md:mt-0'>
+        {/* <div className='mt-4 flex md:ml-4 md:mt-0'>
           <button
             type='button'
             className='inline-flex items-center rounded-md bg-white px-3 py-2 text-sm font-semibold text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 hover:bg-gray-50'
@@ -20,7 +20,7 @@ export default function Example({ text }) {
           >
             Publish
           </button>
-        </div>
+        </div> */}
       </div>
     </header>
   );

--- a/app/src/components/HeadingDashboard.jsx
+++ b/app/src/components/HeadingDashboard.jsx
@@ -1,13 +1,10 @@
-import {
-  useEffect,
-  useState,
-} from 'react';
+import { useEffect, useState } from 'react';
 
 import ProgressBar from '../components/ProgressBar';
 import getBaseUrl from '../helpers/baseUrlHelper';
 import { getLicenseKey } from '../helpers/util';
 
-export default function HeadingDashboard() {
+export default function HeadingDashboard({ totalCreditsRemaining }) {
   const [isGenerating, setIsGenerating] = useState(false);
   const [isScanning, setIsScanning] = useState(false);
   const [progress, setProgress] = useState(0);
@@ -208,7 +205,12 @@ export default function HeadingDashboard() {
             type='button'
             id='bulkGenerateBtn'
             onClick={fetchImages}
-            disabled={!licenseKey || isGenerating || isScanning} // Disable if progress is ongoing
+            disabled={
+              !totalCreditsRemaining ||
+              !licenseKey ||
+              isGenerating ||
+              isScanning
+            } // Disable if progress is ongoing
             className='disabled:bg-gray-400 ml-3 inline-flex items-center rounded-md bg-indigo-600 px-3 py-2 text-sm font-semibold text-white shadow-sm hover-bg-indigo-700 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600'
           >
             {isGenerating ? 'Generating...' : 'Bulk Generate'}

--- a/app/src/components/HeadingDashboard.jsx
+++ b/app/src/components/HeadingDashboard.jsx
@@ -1,48 +1,32 @@
-import React, { useState, useEffect } from 'react';
+import { useState } from 'react';
+
 import ProgressBar from '../components/ProgressBar';
 import getBaseUrl from '../helpers/baseUrlHelper';
 import { getLicenseKey } from '../helpers/util';
 
-export default function HeadingDashboard({ data }) {
+export default function HeadingDashboard() {
   const [isGenerating, setIsGenerating] = useState(false);
   const [isScanning, setIsScanning] = useState(false);
   const [progress, setProgress] = useState(0);
-  const [images, setImages] = useState([]);
-
-  // Use useEffect to watch for changes in isGenerating and isScanning
-  useEffect(() => {
-    if (isGenerating || isScanning) {
-      // Disable buttons when progress is ongoing
-      document.getElementById('bulkGenerateBtn').disabled = true;
-      document.getElementById('scanImagesBtn').disabled = true;
-    } else {
-      // Enable buttons when progress is not ongoing
-      document.getElementById('bulkGenerateBtn').disabled = false;
-      document.getElementById('scanImagesBtn').disabled = false;
-    }
-    
-  }, [isGenerating, isScanning, images]);
 
   const fetchImages = () => {
     handleScanImagesClick();
-    fetch(getBaseUrl()+'/wp-json/altly/v1/bulk-generate',
-    {
+    fetch(getBaseUrl() + '/wp-json/altly/v1/bulk-generate', {
       method: 'GET',
       headers: {
         'Content-Type': 'application/json',
-      }
+      },
     })
-    .then(response => response.json())
-    .then(data => {
-      setImages(data);
-      processImages(data);
-    })
-    .catch(error => console.error('Error:', error));
+      .then((response) => response.json())
+      .then((data) => {
+        processImages(data);
+      })
+      .catch((error) => console.error('Error:', error));
   };
 
   // const processImagesv1 = async (images) => {
   //   const apiKey = await getLicenseKey();
-    
+
   //   images.forEach(image => {
   //     const images = [
   //       {
@@ -53,7 +37,7 @@ export default function HeadingDashboard({ data }) {
   //         platform_name: "WordPress"
   //       }
   //     ];
-      
+
   //     const jsonBody = JSON.stringify({ images: images });
 
   //     fetch('https://api.altly.io/v1/batch/queue', {
@@ -62,7 +46,7 @@ export default function HeadingDashboard({ data }) {
   //         'Content-Type': 'application/json',
   //         'Authorization': 'Bearer ' + apiKey,
   //       },
-        
+
   //       body: jsonBody,
   //     })
   //     .then(response => response.json())
@@ -73,10 +57,10 @@ export default function HeadingDashboard({ data }) {
 
   // const processImagesv2 = async (images) => {
   //   const apiKey = await getLicenseKey();
-  
+
   //   // Function to introduce a delay
   //   const delay = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
-  
+
   //   for (const image of images) {
   //     const imagesArray = [
   //       {
@@ -87,9 +71,9 @@ export default function HeadingDashboard({ data }) {
   //         platform_name: "WordPress"
   //       }
   //     ];
-  
+
   //     const jsonBody = JSON.stringify({ images: imagesArray });
-  
+
   //     try {
   //       const response = await fetch('https://api.altly.io/v1/batch/queue', {
   //         method: 'POST',
@@ -99,26 +83,32 @@ export default function HeadingDashboard({ data }) {
   //         },
   //         body: jsonBody,
   //       });
-  
+
   //       const data = await response.json();
   //       // console.log('Success:', data);
-  
+
   //       // Introduce a delay before proceeding to the next image
   //       // Adjust the delay time as needed (1000ms is 1 second)
-  //       await delay(50); 
+  //       await delay(50);
   //     } catch (error) {
   //       console.error('Error:', error);
   //     }
   //   }
   // };
 
-  const processImages = async (images, batchSize = 10, delayDuration = 1000) => {
+  const processImages = async (
+    images,
+    batchSize = 10,
+    delayDuration = 1000
+  ) => {
     const apiKey = await getLicenseKey();
-  
+
     for (let i = 0; i < images.length; i += batchSize) {
       const batch = images.slice(i, i + batchSize);
-      const promises = batch.map(image => sendImageProcessingRequest(image, apiKey));
-  
+      const promises = batch.map((image) =>
+        sendImageProcessingRequest(image, apiKey)
+      );
+
       try {
         await Promise.all(promises);
         // console.log('Batch success:', results);
@@ -126,40 +116,41 @@ export default function HeadingDashboard({ data }) {
         // console.error('Batch error:', error);
         // Implement retry logic here if necessary
       }
-  
+
       // Wait before sending the next batch
       await delay(delayDuration);
     }
   };
-  
+
   const sendImageProcessingRequest = async (image, apiKey) => {
     const requestBody = JSON.stringify({
-      images: [{
-        url: image.url,
-        api_endpoint: image.api_endpoint,
-        asset_id: image.asset_id,
-        transaction_id: image.transaction_id,
-        platform_name: "WordPress"
-      }]
+      images: [
+        {
+          url: image.url,
+          api_endpoint: image.api_endpoint,
+          asset_id: image.asset_id,
+          transaction_id: image.transaction_id,
+          platform_name: 'WordPress',
+        },
+      ],
     });
-  
+
     const response = await fetch('https://api.altly.io/v1/batch/queue', {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
-        'Authorization': `Bearer ${apiKey}`,
+        Authorization: `Bearer ${apiKey}`,
       },
       body: requestBody,
     });
-  
+
     if (!response.ok) throw new Error(`HTTP error! status: ${response.status}`);
-  
+
     return response.json();
   };
-  
-  const delay = (ms) => new Promise(resolve => setTimeout(resolve, ms));
-  
-  
+
+  const delay = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
   const handleScanImagesClick = () => {
     if (!isScanning) {
       setIsScanning(true);

--- a/app/src/components/HeadingDashboard.jsx
+++ b/app/src/components/HeadingDashboard.jsx
@@ -4,7 +4,10 @@ import ProgressBar from '../components/ProgressBar';
 import getBaseUrl from '../helpers/baseUrlHelper';
 import { getLicenseKey } from '../helpers/util';
 
-export default function HeadingDashboard({ totalCreditsRemaining }) {
+export default function HeadingDashboard({
+  totalCreditsRemaining,
+  imagesMissingAltText,
+}) {
   const [isGenerating, setIsGenerating] = useState(false);
   const [isScanning, setIsScanning] = useState(false);
   const [progress, setProgress] = useState(0);
@@ -206,7 +209,8 @@ export default function HeadingDashboard({ totalCreditsRemaining }) {
             id='bulkGenerateBtn'
             onClick={fetchImages}
             disabled={
-              !totalCreditsRemaining ||
+              imagesMissingAltText < 1 ||
+              totalCreditsRemaining < 1 ||
               !licenseKey ||
               isGenerating ||
               isScanning

--- a/app/src/components/ImageGrid.jsx
+++ b/app/src/components/ImageGrid.jsx
@@ -10,12 +10,13 @@ export default function ImageGrid({
   onDataChange,
   totalCreditsRemaining,
   statsLoading,
+  imagesMissingAltText,
+  setImagesMissingAltText,
 }) {
   const [files, setFiles] = useState([]);
   const [isLoading, setIsLoading] = useState(true);
   const [averageConfidenceScore, setAverageConfidenceScore] = useState(null);
   const [totalImages, setTotalImages] = useState(0);
-  const [imagesMissingAltText, setImagesMissingAltText] = useState(0);
   const [altImageData, setAltImageData] = useState();
 
   const [currentPage, setCurrentPage] = useState(1);

--- a/app/src/components/ImageGrid.jsx
+++ b/app/src/components/ImageGrid.jsx
@@ -1,17 +1,17 @@
-import React, { useState, useEffect } from 'react';
+import React, { useEffect, useState } from 'react';
+
 import ImageGridLoader from '../components/ImageGridLoader';
-import Stats from '../components/Stats';
 import Pagination from '../components/Pagination';
+import Stats from '../components/Stats';
 import StatsLoader from '../components/StatsLoader';
 import getBaseUrl from '../helpers/baseUrlHelper';
 
-export default function ImageGrid({ onDataChange }) {
+export default function ImageGrid({ onDataChange, totalCreditsRemaining }) {
   const [files, setFiles] = useState([]);
   const [isLoading, setIsLoading] = useState(true);
   const [statsLoading, setstatsLoading] = useState(true);
   const [averageConfidenceScore, setAverageConfidenceScore] = useState(null);
   const [totalImages, setTotalImages] = useState(0);
-  const [totalCreditsRemaining, setTotalCreditsRemaining] = useState(0);
   const [imagesMissingAltText, setImagesMissingAltText] = useState(0);
   const [altImageData, setAltImageData] = useState();
 
@@ -39,14 +39,17 @@ export default function ImageGrid({ onDataChange }) {
   };
 
   const handleNextPage = () => {
-    setCurrentPage((prevPage) => (prevPage < Math.ceil(files.length / itemsPerPage) ? prevPage + 1 : prevPage));
+    setCurrentPage((prevPage) =>
+      prevPage < Math.ceil(files.length / itemsPerPage)
+        ? prevPage + 1
+        : prevPage
+    );
   };
 
   /*
     Update the URL to the CMS API endpoint.
   */
-  const cmsImageApiUrl =
-    getBaseUrl()+'/wp-json/altly/v1/get-media-details';
+  const cmsImageApiUrl = getBaseUrl() + '/wp-json/altly/v1/get-media-details';
 
   useEffect(() => {
     const fetchData = async (pageUrl) => {
@@ -55,32 +58,33 @@ export default function ImageGrid({ onDataChange }) {
         const data = await response.json();
 
         const itemsWithMissingAltText = data.media_details
-        .filter(item => !item.alt_text || item.alt_text.trim() === '') // Filter items with missing or empty alt_text
-        .map(item => ({
-          // Map each filtered item to a new object structure
-          alt_text: item.alt_text,
-          file_path: item.file_path,
-          id: item.id,
-          metadata: item.metadata,
-          url: item.url
-        }));
+          .filter((item) => !item.alt_text || item.alt_text.trim() === '') // Filter items with missing or empty alt_text
+          .map((item) => ({
+            // Map each filtered item to a new object structure
+            alt_text: item.alt_text,
+            file_path: item.file_path,
+            id: item.id,
+            metadata: item.metadata,
+            url: item.url,
+          }));
 
         // console.log('All Data:', data);
         // console.log('Missing Alt Text:', itemsWithMissingAltText);
-        // we're setting this below so we can send it to the dashboard which 
+        // we're setting this below so we can send it to the dashboard which
         // connects and sends it to the HeadingDashboard for bulk generation
         setAltImageData(itemsWithMissingAltText);
 
         // Process the data and create new file objects, these are the images displayed on the plugin dashboard
-        const newFiles = data.media_details.filter(item => !item.alt_text || item.alt_text.trim() === '').map((item) => ({
-          id: item.id,
-          title: `Image ${item.id}`,
-          size: `${item.metadata.width}x${item.metadata.height}`,
-          altText: item.alt_text,
-          confidenceScore: Math.round(item.confidence_score * 100) / 100,
-          source: item.url,
-        }));
-
+        const newFiles = data.media_details
+          .filter((item) => !item.alt_text || item.alt_text.trim() === '')
+          .map((item) => ({
+            id: item.id,
+            title: `Image ${item.id}`,
+            size: `${item.metadata.width}x${item.metadata.height}`,
+            altText: item.alt_text,
+            confidenceScore: Math.round(item.confidence_score * 100) / 100,
+            source: item.url,
+          }));
 
         setFiles(newFiles);
         setTotalImages(data.total_images);
@@ -111,46 +115,18 @@ export default function ImageGrid({ onDataChange }) {
 
   // const validateLicenseUrl = 'http://localhost:3000/validate/license-key';
 
-  useEffect(() => {
-    const getUserCredits = async () => {
-      const url = getBaseUrl()+'/wp-json/altly/v1/get-user-credits';
-      try {
-        const response = await fetch(url);
-
-        if (!response.ok) {
-          throw new Error(`Error: ${response.status} ${response.statusText}`);
-        }
-
-        const credits = await response.json();
-        
-        if (credits !== false) {
-          // setUserData({ credits: data.credits });
-          setTotalCreditsRemaining(credits);
-          setstatsLoading(false);
-        } else {
-          setstatsLoading(false);
-        }
-
-        // console.log(data);
-
-      } catch (error) {
-        setstatsLoading(false);
-        console.error('Error fetching user credits:', error);
-      }
-    };
-
-    getUserCredits();
-  }, []);
-
   return (
     <div>
-      {statsLoading ? <StatsLoader /> : 
-      <Stats
-        totalImages={totalImages}
-        missingAltText={imagesMissingAltText}
-        score={averageConfidenceScore}
-        credits={totalCreditsRemaining}
-      />}
+      {statsLoading ? (
+        <StatsLoader />
+      ) : (
+        <Stats
+          totalImages={totalImages}
+          missingAltText={imagesMissingAltText}
+          score={averageConfidenceScore}
+          credits={totalCreditsRemaining}
+        />
+      )}
       {isLoading ? (
         <ImageGridLoader />
       ) : (
@@ -207,7 +183,3 @@ export default function ImageGrid({ onDataChange }) {
     </div>
   );
 }
-
-
-
-

--- a/app/src/components/ImageGrid.jsx
+++ b/app/src/components/ImageGrid.jsx
@@ -6,10 +6,13 @@ import Stats from '../components/Stats';
 import StatsLoader from '../components/StatsLoader';
 import getBaseUrl from '../helpers/baseUrlHelper';
 
-export default function ImageGrid({ onDataChange, totalCreditsRemaining }) {
+export default function ImageGrid({
+  onDataChange,
+  totalCreditsRemaining,
+  statsLoading,
+}) {
   const [files, setFiles] = useState([]);
   const [isLoading, setIsLoading] = useState(true);
-  const [statsLoading, setstatsLoading] = useState(true);
   const [averageConfidenceScore, setAverageConfidenceScore] = useState(null);
   const [totalImages, setTotalImages] = useState(0);
   const [imagesMissingAltText, setImagesMissingAltText] = useState(0);

--- a/app/src/components/Input.jsx
+++ b/app/src/components/Input.jsx
@@ -75,7 +75,7 @@ export default function Input({
         </p>
       ) : isError ? (
         <p className='mt-2 text-sm text-red-600' id={`${name}-error`}>
-          Value is not correct.
+          License Key is not valid. Please try another key.
         </p>
       ) : isValueCorrect ? (
         <p className='mt-2 text-sm text-green-600'>{successMessage}</p>

--- a/app/src/components/Input.jsx
+++ b/app/src/components/Input.jsx
@@ -1,7 +1,8 @@
 import React from 'react';
+
 import {
-  ExclamationCircleIcon,
   CheckCircleIcon,
+  ExclamationCircleIcon,
 } from '@heroicons/react/20/solid';
 
 export default function Input({
@@ -9,14 +10,15 @@ export default function Input({
   type,
   placeholder,
   name,
-  value,
+  value = '', // Provide default value
   onChange,
-  isError,
-  isValueCorrect,
-  successMessage,
-  disabled,
+  isError = false,
+  isValueCorrect = false,
+  successMessage = '',
+  disabled = false,
 }) {
-  const isEmpty = value.trim() === '';
+  const [isEmpty, setIsEmpty] = React.useState(false);
+  // Safely check if empty, handling undefined/null cases
 
   return (
     <div className='mb-10'>
@@ -30,10 +32,13 @@ export default function Input({
         <input
           type={type}
           name={name}
+          onBlur={() => {
+            value.length === 0 ? setIsEmpty(true) : setIsEmpty(false);
+          }}
           disabled={disabled}
           id={name}
           className={`block w-full rounded-md border-0 py-1.5 pr-10 ${
-            isEmpty
+            isEmpty && !disabled
               ? 'text-red-900 ring-1 ring-inset ring-red-300 placeholder:text-red-300 focus:ring-2 focus:ring-inset focus:ring-red-500'
               : isValueCorrect
               ? 'text-green-900 ring-1 ring-inset ring-green-300 placeholder:text-green-300 focus:ring-2 focus:ring-inset focus:ring-green-500'
@@ -46,7 +51,7 @@ export default function Input({
           onChange={onChange}
         />
         <div className='pointer-events-none absolute inset-y-0 right-0 flex items-center pr-3'>
-          {isEmpty ? (
+          {isEmpty && !disabled ? (
             <ExclamationCircleIcon
               className='h-5 w-5 text-red-500'
               aria-hidden='true'
@@ -64,7 +69,7 @@ export default function Input({
           )}
         </div>
       </div>
-      {isEmpty ? (
+      {isEmpty && !disabled ? (
         <p className='mt-2 text-sm text-red-600' id={`${name}-error`}>
           Field cannot be empty.
         </p>

--- a/app/src/components/Stats.jsx
+++ b/app/src/components/Stats.jsx
@@ -40,7 +40,7 @@ export default function Example({
         </dt>
         <dd
           className={`w-full flex-none text-3xl font-medium leading-10 tracking-tight ${
-            credits ? 'text-gray-900' : 'text-red-500'
+            credits < 1 ? 'text-gray-900' : 'text-red-500'
           }`}
         >
           {credits}

--- a/app/src/components/Stats.jsx
+++ b/app/src/components/Stats.jsx
@@ -38,7 +38,11 @@ export default function Example({
         <dt className='text-sm font-medium leading-6 text-gray-500'>
           Credits Remaining
         </dt>
-        <dd className='w-full flex-none text-3xl font-medium leading-10 tracking-tight text-gray-900'>
+        <dd
+          className={`w-full flex-none text-3xl font-medium leading-10 tracking-tight ${
+            credits ? 'text-gray-900' : 'text-red-500'
+          }`}
+        >
           {credits}
         </dd>
       </div>

--- a/app/src/components/Stats.jsx
+++ b/app/src/components/Stats.jsx
@@ -40,7 +40,7 @@ export default function Example({
         </dt>
         <dd
           className={`w-full flex-none text-3xl font-medium leading-10 tracking-tight ${
-            credits < 1 ? 'text-gray-900' : 'text-red-500'
+            credits > 0 ? 'text-gray-900' : 'text-red-500'
           }`}
         >
           {credits}

--- a/app/src/components/Stats.jsx
+++ b/app/src/components/Stats.jsx
@@ -36,7 +36,7 @@ export default function Example({
       </div> */}
       <div className='flex flex-wrap items-baseline justify-between gap-x-4 gap-y-2 bg-white px-4 py-10 sm:px-6 xl:px-8'>
         <dt className='text-sm font-medium leading-6 text-gray-500'>
-          Credits Remaining
+          Images Remaining
         </dt>
         <dd
           className={`w-full flex-none text-3xl font-medium leading-10 tracking-tight ${

--- a/app/src/pages/Dashboard.jsx
+++ b/app/src/pages/Dashboard.jsx
@@ -7,6 +7,7 @@ import getBaseUrl from '../helpers/baseUrlHelper';
 export default function Dashboard() {
   const [imageData, setImageData] = useState(null);
   const [totalCreditsRemaining, setTotalCreditsRemaining] = useState(0);
+  const [statsLoading, setstatsLoading] = useState(true);
 
   // Function to update the state, which will be passed to ImageGrid
   const handleDataChange = (newData) => {
@@ -48,6 +49,7 @@ export default function Dashboard() {
       <HeadingDashboard
         data={imageData}
         totalCreditsRemaining={totalCreditsRemaining}
+        statsLoading={statsLoading}
       />
       <ImageGrid
         onDataChange={handleDataChange}

--- a/app/src/pages/Dashboard.jsx
+++ b/app/src/pages/Dashboard.jsx
@@ -8,6 +8,7 @@ export default function Dashboard() {
   const [imageData, setImageData] = useState(null);
   const [totalCreditsRemaining, setTotalCreditsRemaining] = useState(0);
   const [statsLoading, setstatsLoading] = useState(true);
+  const [imagesMissingAltText, setImagesMissingAltText] = useState(0);
 
   // Function to update the state, which will be passed to ImageGrid
   const handleDataChange = (newData) => {
@@ -50,10 +51,13 @@ export default function Dashboard() {
         data={imageData}
         totalCreditsRemaining={totalCreditsRemaining}
         statsLoading={statsLoading}
+        imagesMissingAltText={imagesMissingAltText}
       />
       <ImageGrid
         onDataChange={handleDataChange}
         totalCreditsRemaining={totalCreditsRemaining}
+        imagesMissingAltText={imagesMissingAltText}
+        setImagesMissingAltText={setImagesMissingAltText}
       />
     </>
   );

--- a/app/src/pages/Dashboard.jsx
+++ b/app/src/pages/Dashboard.jsx
@@ -1,21 +1,58 @@
-import React, { useState } from 'react';
-import ImageGrid from '../components/ImageGrid';
+import { useEffect, useState } from 'react';
+
 import HeadingDashboard from '../components/HeadingDashboard';
+import ImageGrid from '../components/ImageGrid';
 import getBaseUrl from '../helpers/baseUrlHelper';
 
 export default function Dashboard() {
   const [imageData, setImageData] = useState(null);
-
+  const [totalCreditsRemaining, setTotalCreditsRemaining] = useState(0);
 
   // Function to update the state, which will be passed to ImageGrid
-  const handleDataChange = newData => {
+  const handleDataChange = (newData) => {
     setImageData(newData);
   };
 
+  useEffect(() => {
+    const getUserCredits = async () => {
+      const url = getBaseUrl() + '/wp-json/altly/v1/get-user-credits';
+      try {
+        const response = await fetch(url);
+
+        if (!response.ok) {
+          throw new Error(`Error: ${response.status} ${response.statusText}`);
+        }
+
+        const credits = await response.json();
+
+        if (credits !== false) {
+          // setUserData({ credits: data.credits });
+          setTotalCreditsRemaining(credits);
+          setstatsLoading(false);
+        } else {
+          setstatsLoading(false);
+        }
+
+        // console.log(data);
+      } catch (error) {
+        setstatsLoading(false);
+        console.error('Error fetching user credits:', error);
+      }
+    };
+
+    getUserCredits();
+  }, []);
+
   return (
     <>
-      <HeadingDashboard data={imageData} />
-      <ImageGrid onDataChange={handleDataChange} />
+      <HeadingDashboard
+        data={imageData}
+        totalCreditsRemaining={totalCreditsRemaining}
+      />
+      <ImageGrid
+        onDataChange={handleDataChange}
+        totalCreditsRemaining={totalCreditsRemaining}
+      />
     </>
   );
 }

--- a/app/src/pages/Settings.jsx
+++ b/app/src/pages/Settings.jsx
@@ -1,4 +1,7 @@
-import React, { useEffect, useState } from 'react';
+import React, {
+  useEffect,
+  useState,
+} from 'react';
 
 import Form from '../components/Form';
 import Heading from '../components/Heading';
@@ -24,7 +27,6 @@ export default function Example() {
   // Function to handle input change
   const handleInputChange = (event) => {
     setInputValue(event.target.value);
-    setIsError(false); // Reset error state when input changes
   };
 
   const handleSaveClick = async (formData) => {
@@ -104,16 +106,18 @@ export default function Example() {
       const response = await fetch(
         getBaseUrl() + '/wp-json/altly/v1/license-key'
       );
+
       const data = await response.json();
 
-      if (response.ok && data.license_key) {
+      if (response?.ok && data?.license_key) {
         setInputValue(data.license_key); // Set the license key if it exists
         setIsValueCorrect(true); // Assuming the key is correct if it's present
         setIsLoading(false);
+        setSuccessMessage('License key is valid');
       } else {
         setInputValue('');
         setIsLoading(false);
-        throw new Error('License key not found');
+        console.log('License key not found');
       }
     } catch (error) {
       console.error('Error while loading the license key:', error);
@@ -130,7 +134,7 @@ export default function Example() {
     loadLicenseKey();
   }, []); // The empty array ensures this effect runs only once
 
-  const hasValidLicense = inputValue.length > 0 && isValueCorrect;
+  const hasValidLicense = isValueCorrect && inputValue?.length > 0;
 
   return (
     <div>
@@ -147,17 +151,17 @@ export default function Example() {
             placeholder='xxx-xxx-xxx'
             name='license-key'
             value={inputValue} // Pass the input value
-            onChange={handleInputChange} // Pass the onChange handler
             isError={isError}
             isValueCorrect={isValueCorrect}
-            successMessage='License key is valid'
+            successMessage={successMessage}
             disabled={hasValidLicense}
+            onChange={handleInputChange} // Pass the onChange handler
           />
           <button
             type='submit'
-            className='rounded-md bg-indigo-600 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600'
+            className='disabled:bg-gray-400 rounded-md bg-indigo-600 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600'
           >
-            {`${hasValidLicense ? 'Save' : 'Remove'} License`}
+            {`${hasValidLicense ? 'Remove' : 'Save'} License`}
           </button>
         </Form>
       )}

--- a/app/src/pages/Settings.jsx
+++ b/app/src/pages/Settings.jsx
@@ -1,7 +1,8 @@
-import React, { useState, useEffect } from 'react';
+import React, { useEffect, useState } from 'react';
+
+import Form from '../components/Form';
 import Heading from '../components/Heading';
 import Input from '../components/Input';
-import Form from '../components/Form';
 import InputLoader from '../components/InputLoader';
 import getBaseUrl from '../helpers/baseUrlHelper';
 
@@ -14,7 +15,7 @@ export default function Example() {
 
   // State to track whether there's an error
   const [isError, setIsError] = useState(false);
-  
+
   // Track load state
   const [isLoading, setIsLoading] = useState(true);
 
@@ -34,7 +35,7 @@ export default function Example() {
     try {
       // Make a POST request to the API endpoint
       const response = await fetch(
-        getBaseUrl()+'/wp-json/altly/v1/license-key',
+        getBaseUrl() + '/wp-json/altly/v1/license-key',
         {
           method: 'POST',
           headers: {
@@ -74,7 +75,7 @@ export default function Example() {
   const handleLicenseRemoval = async () => {
     try {
       const response = await fetch(
-        getBaseUrl()+'/wp-json/altly/v1/remove-license-key'
+        getBaseUrl() + '/wp-json/altly/v1/remove-license-key'
       );
       // const data = await response.json();
 
@@ -94,21 +95,14 @@ export default function Example() {
         error.message || 'An error occurred while loading the license key.'
       );
     }
-  }
-
-  // Function to validate the input (replace with your validation logic)
-  const validateInput = (value) => {
-    // Replace this with your validation logic
-    return value === 'correctValue';
   };
 
   // Function to load the license key from the API
-  
 
   const loadLicenseKey = async () => {
     try {
       const response = await fetch(
-        getBaseUrl()+'/wp-json/altly/v1/license-key'
+        getBaseUrl() + '/wp-json/altly/v1/license-key'
       );
       const data = await response.json();
 
@@ -136,29 +130,17 @@ export default function Example() {
     loadLicenseKey();
   }, []); // The empty array ensures this effect runs only once
 
+  const hasValidLicense = inputValue.length > 0 && isValueCorrect;
+
   return (
     <div>
       <Heading text='Settings' />
       {isLoading ? (
         <InputLoader /> // Show a loading indicator
-      ) : inputValue.length > 0 && isValueCorrect ? (
-        <>
-          <Input
-            label='License Key'
-            type='text'
-            placeholder='xxx-xxx-xxx'
-            name='license-key'
-            value={inputValue} // Pass the input value
-            onChange={handleInputChange} // Pass the onChange handler
-            isError={isError}
-            isValueCorrect={isValueCorrect}
-            successMessage='License key is valid'
-            disabled={true}
-          />
-          <button className='rounded-md bg-indigo-600 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600' onClick={handleLicenseRemoval}>Remove License</button>
-        </>
       ) : (
-        <Form onSubmit={handleSaveClick}>
+        <Form
+          onSubmit={hasValidLicense ? handleLicenseRemoval : handleSaveClick}
+        >
           <Input
             label='License Key'
             type='text'
@@ -169,12 +151,13 @@ export default function Example() {
             isError={isError}
             isValueCorrect={isValueCorrect}
             successMessage='License key is valid'
+            disabled={hasValidLicense}
           />
           <button
             type='submit'
             className='rounded-md bg-indigo-600 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600'
           >
-            Save License
+            {`${hasValidLicense ? 'Save' : 'Remove'} License`}
           </button>
         </Form>
       )}

--- a/app/src/pages/Settings.jsx
+++ b/app/src/pages/Settings.jsx
@@ -1,7 +1,4 @@
-import React, {
-  useEffect,
-  useState,
-} from 'react';
+import React, { useEffect, useState } from 'react';
 
 import Form from '../components/Form';
 import Heading from '../components/Heading';
@@ -49,8 +46,6 @@ export default function Example() {
 
       const data = await response.json();
 
-      // console.log(data);
-
       if (response.ok) {
         setIsValueCorrect(true);
         setIsError(false);
@@ -81,14 +76,11 @@ export default function Example() {
       );
       // const data = await response.json();
 
-      if (response.ok) {
-        setIsLoading(false);
-        loadLicenseKey();
-      } else {
-        setIsLoading(false);
-        loadLicenseKey();
-        throw new Error('License key not found');
-      }
+      setIsLoading(false);
+      loadLicenseKey();
+      setSuccessMessage('');
+      setIsValueCorrect(false);
+      setIsError(false);
     } catch (error) {
       console.error('Error while loading the license key:', error);
       setIsError(true);

--- a/app/vite.config.js
+++ b/app/vite.config.js
@@ -1,4 +1,5 @@
 import { defineConfig } from 'vite';
+
 import react from '@vitejs/plugin-react';
 
 // https://vitejs.dev/config/
@@ -16,9 +17,9 @@ export default defineConfig({
     },
     rollupOptions: {
       output: {
-        entryFileNames: `assets/[name].js`,
-        chunkFileNames: `assets/[name].js`,
-        assetFileNames: `assets/[name].[ext]`,
+        entryFileNames: `assets/[name]-[hash].js`,
+        chunkFileNames: `assets/[name]-[hash].js`,
+        assetFileNames: `assets/[name]-[hash].[ext]`,
       },
     },
   },

--- a/index.php
+++ b/index.php
@@ -34,7 +34,7 @@ function enqueue_ai_alt_text_script()
     // Enqueue your script with a unique handle, source URL, and any necessary dependencies
     wp_enqueue_script(
       'altly', // Unique handle
-      plugin_dir_url(__FILE__) . '/app/dist/assets/index-e117008b.js', // Source URL
+      plugin_dir_url(__FILE__) . '/app/dist/assets/index-12608180.js', // Source URL
       array(), // Dependencies (if any)
       '5', // Version
       true // Load script in the footer

--- a/index.php
+++ b/index.php
@@ -4,7 +4,7 @@
 
 /*
 Plugin Name: Altly - Alt Text Generator
-Version: 1.1.3
+Version: 1.1.4
 Description: A plugin to generate alt text for images using AI
 Author: Prolific Digital
 */

--- a/index.php
+++ b/index.php
@@ -34,7 +34,7 @@ function enqueue_ai_alt_text_script()
     // Enqueue your script with a unique handle, source URL, and any necessary dependencies
     wp_enqueue_script(
       'altly', // Unique handle
-      plugin_dir_url(__FILE__) . '/app/dist/assets/index-939e5311.js', // Source URL
+      plugin_dir_url(__FILE__) . '/app/dist/assets/index-cc03a44a.js', // Source URL
       array(), // Dependencies (if any)
       '5', // Version
       true // Load script in the footer
@@ -43,7 +43,7 @@ function enqueue_ai_alt_text_script()
     // Enqueue your CSS with a unique handle, source URL, and any necessary dependencies
     wp_enqueue_style(
       'altly', // Unique handle
-      plugin_dir_url(__FILE__) . '/app/dist/assets/index-cc03a44a.css', // Source URL
+      plugin_dir_url(__FILE__) . '/app/dist/assets/index-939e5311.css', // Source URL
       array(), // Dependencies (if any)
       '5' // Version
     );

--- a/index.php
+++ b/index.php
@@ -34,7 +34,7 @@ function enqueue_ai_alt_text_script()
     // Enqueue your script with a unique handle, source URL, and any necessary dependencies
     wp_enqueue_script(
       'altly', // Unique handle
-      plugin_dir_url(__FILE__) . '/app/dist/assets/index-23bc02c4.js', // Source URL
+      plugin_dir_url(__FILE__) . '/app/dist/assets/index-e117008b.js', // Source URL
       array(), // Dependencies (if any)
       '5', // Version
       true // Load script in the footer

--- a/index.php
+++ b/index.php
@@ -4,7 +4,7 @@
 
 /*
 Plugin Name: Altly - Alt Text Generator
-Version: 1.1.2
+Version: 1.1.3
 Description: A plugin to generate alt text for images using AI
 Author: Prolific Digital
 */
@@ -34,7 +34,7 @@ function enqueue_ai_alt_text_script()
     // Enqueue your script with a unique handle, source URL, and any necessary dependencies
     wp_enqueue_script(
       'altly', // Unique handle
-      plugin_dir_url(__FILE__) . '/app/dist/assets/index-ea9d8d7d.js', // Source URL
+      plugin_dir_url(__FILE__) . '/app/dist/assets/index-876c50f7.js', // Source URL
       array(), // Dependencies (if any)
       '5', // Version
       true // Load script in the footer

--- a/index.php
+++ b/index.php
@@ -4,7 +4,7 @@
 
 /*
 Plugin Name: Altly - Alt Text Generator
-Version: 1.1.4
+Version: 1.1.5
 Description: A plugin to generate alt text for images using AI
 Author: Prolific Digital
 */
@@ -34,7 +34,7 @@ function enqueue_ai_alt_text_script()
     // Enqueue your script with a unique handle, source URL, and any necessary dependencies
     wp_enqueue_script(
       'altly', // Unique handle
-      plugin_dir_url(__FILE__) . '/app/dist/assets/index-7f3b2213.js', // Source URL
+      plugin_dir_url(__FILE__) . '/app/dist/assets/index-939e5311.js', // Source URL
       array(), // Dependencies (if any)
       '5', // Version
       true // Load script in the footer
@@ -43,7 +43,7 @@ function enqueue_ai_alt_text_script()
     // Enqueue your CSS with a unique handle, source URL, and any necessary dependencies
     wp_enqueue_style(
       'altly', // Unique handle
-      plugin_dir_url(__FILE__) . '/app/dist/assets/index-939e5311.css', // Source URL
+      plugin_dir_url(__FILE__) . '/app/dist/assets/index-cc03a44a.css', // Source URL
       array(), // Dependencies (if any)
       '5' // Version
     );

--- a/index.php
+++ b/index.php
@@ -34,7 +34,7 @@ function enqueue_ai_alt_text_script()
     // Enqueue your script with a unique handle, source URL, and any necessary dependencies
     wp_enqueue_script(
       'altly', // Unique handle
-      plugin_dir_url(__FILE__) . '/app/dist/assets/index-cc03a44a.js', // Source URL
+      plugin_dir_url(__FILE__) . '/app/dist/assets/index-23bc02c4.js', // Source URL
       array(), // Dependencies (if any)
       '5', // Version
       true // Load script in the footer

--- a/index.php
+++ b/index.php
@@ -34,7 +34,7 @@ function enqueue_ai_alt_text_script()
     // Enqueue your script with a unique handle, source URL, and any necessary dependencies
     wp_enqueue_script(
       'altly', // Unique handle
-      plugin_dir_url(__FILE__) . '/app/dist/assets/index-876c50f7.js', // Source URL
+      plugin_dir_url(__FILE__) . '/app/dist/assets/index-7f3b2213.js', // Source URL
       array(), // Dependencies (if any)
       '5', // Version
       true // Load script in the footer

--- a/routes/Helpers.php
+++ b/routes/Helpers.php
@@ -35,9 +35,10 @@ class Helpers
    *
    * @return array An associative array of header names and values.
    */
-  public function prepareHeaders()
+  public function prepareHeaders($license_key = null)
   {
-    return ['Content-Type' => 'application/json', 'Authorization' => 'Bearer ' . $this->license_key];
+    $key = $this->license_key ? $this->license_key : $license_key;
+    return ['Content-Type' => 'application/json', 'Authorization' => 'Bearer ' . $key];
   }
 
   public function getUserCredits()
@@ -298,13 +299,16 @@ class Helpers
     return $media_details;
   }
 
-  public function callExternalApi()
+  public function callExternalApi($license_key)
   {
+    $key = $this->license_key ? $this->license_key : $license_key;
     $apiUrl = 'https://api.altly.io/v1/validate/license-key';
-    $headers = $this->prepareHeaders();
+    $headers = $this->prepareHeaders($key);
+    $body = json_encode(['license-key' => $key]);
 
     return wp_remote_post($apiUrl, [
       'headers' => $headers,
+      'body'    => $body,
     ]);
   }
 }

--- a/routes/Helpers.php
+++ b/routes/Helpers.php
@@ -41,7 +41,7 @@ class Helpers
     return ['Content-Type' => 'application/json', 'Authorization' => 'Bearer ' . $key];
   }
 
-  public function getUserCredits()
+  public function getUserCredits(): int
   {
     $api_response = $this->callExternalApi($this->license_key);
 
@@ -220,12 +220,21 @@ class Helpers
     return $processing_id;
   }
 
+  /**
+   * Queues images for processing based on available credits
+   * @param array $attachment_ids Array of attachment IDs to process
+   * @return array Queued images (limited by available credits)
+   */
   public function queueImages($attachment_ids)
   {
     $results = [];
-
+    $credits = $this->getUserCredits();
 
     foreach ($attachment_ids as $attachment_id) {
+      if ($credits < 1) {
+        break;
+      }
+
       $asset_id = $attachment_id['id'];
 
       $processing_id = $this->getOrCreateProcessingId($asset_id);
@@ -242,6 +251,8 @@ class Helpers
       ];
 
       $results[] = $images;
+
+      $credits--;
     }
 
     return $results;

--- a/routes/Helpers.php
+++ b/routes/Helpers.php
@@ -51,7 +51,6 @@ class Helpers
 
     $credits = json_decode(wp_remote_retrieve_body($api_response), true)['data']['credits'];
 
-
     return $credits;
   }
 

--- a/routes/LicenseRoute.php
+++ b/routes/LicenseRoute.php
@@ -5,12 +5,13 @@ namespace Altly\AltTextGenerator;
 class LicenseRoute
 {
   private $helper;
-
+  private $license_key;
   public function __construct()
   {
     add_action('rest_api_init', array($this, 'register_license_key_route'));
     add_action('rest_api_init', array($this, 'register_remove_license_key_route'));
     $this->helper = new \Altly\AltTextGenerator\Helpers();
+    $this->license_key = get_option('_altly_license_key');
   }
 
   public function register_license_key_route()
@@ -61,7 +62,7 @@ class LicenseRoute
 
   protected function handleGetRequest()
   {
-    $license_key = get_option('_altly_license_key');
+    $license_key = $this->license_key;
     if ($license_key) {
       return new \WP_REST_Response(['license_key' => $license_key], 200);
     }
@@ -75,7 +76,7 @@ class LicenseRoute
       return new \WP_REST_Response(['error' => 'Missing license key.'], 400);
     }
 
-    $saved_license_key = get_option('_altly_license_key');
+    $saved_license_key = $this->license_key;
     if ($saved_license_key === $license_key) {
       return new \WP_REST_Response(['message' => 'License key is already validated and saved.'], 200);
     }

--- a/routes/MediaDetailsRoute.php
+++ b/routes/MediaDetailsRoute.php
@@ -87,12 +87,6 @@ class MediaDetailsRoute
       return new \WP_REST_Response(['error' => 'Invalid request method'], 405);
     }
 
-    $credits = $this->helper->getUserCredits();
-
-    if ($credits < 1) {
-      return new \WP_REST_Response(['error' => 'Not enough credits to analyze images'], 403);
-    }
-
     $response = $this->helper->queueImages($this->helper->getImagesMissingAltText());
 
     error_log('API Response: ' . print_r($response, true));

--- a/routes/MediaDetailsRoute.php
+++ b/routes/MediaDetailsRoute.php
@@ -87,6 +87,12 @@ class MediaDetailsRoute
       return new \WP_REST_Response(['error' => 'Invalid request method'], 405);
     }
 
+    $credits = $this->helper->getUserCredits();
+
+    if ($credits < 1) {
+      return new \WP_REST_Response(['error' => 'Not enough credits to analyze images'], 403);
+    }
+
     $response = $this->helper->queueImages($this->helper->getImagesMissingAltText());
 
     error_log('API Response: ' . print_r($response, true));

--- a/routes/UserRoute.php
+++ b/routes/UserRoute.php
@@ -21,7 +21,7 @@ class UserRoute
     ));
   }
 
-  public function get_user_credits($request)
+  public function get_user_credits()
   {
     return $this->helper->getUserCredits();
   }

--- a/routes/UserRoute.php
+++ b/routes/UserRoute.php
@@ -2,12 +2,18 @@
 
 namespace Altly\AltTextGenerator;
 
-class UserRoute {
-  public function __construct() {
+class UserRoute
+{
+  private $helper;
+
+  public function __construct()
+  {
     add_action('rest_api_init', array($this, 'register_user_route'));
+    $this->helper = new \Altly\AltTextGenerator\Helpers();
   }
 
-  public function register_user_route() {
+  public function register_user_route()
+  {
     register_rest_route('altly/v1', 'get-user-credits', array(
       'methods' => 'GET',
       'callback' => array($this, 'get_user_credits'),
@@ -15,15 +21,8 @@ class UserRoute {
     ));
   }
 
-  public function get_user_credits($request) {
-    if ('GET' !== $request->get_method()) {
-      // Optionally handle non-GET requests or return a method not allowed response
-      return new \WP_REST_Response(['error' => 'Method Not Allowed'], 405);
-    }
-
-    $credits = get_option('_altly_license_key_user_credits');
-
-    return $credits;
+  public function get_user_credits($request)
+  {
+    return $this->helper->getUserCredits();
   }
-  
 }


### PR DESCRIPTION
This PR is coming into the plugin-v1 branch. Once merged, we'll merge it into main and create a release.

### User Experience Changes
- License Key Input no longer shows missing input error upon loading.
- When License Key is removed, all colors/messages/icons are removed.
- When License Key is removed, "Images Remaining" is set to 0.
- "Credits" are renamed "Images" for clarity (I did this after I filmed the demo).
- Uploading more Images than credits available does not overflow anymore.
- Bulk Generating only generates number of images equal to remaining credits.
- Bulk Generate button is not enabled unless License Key is available and Images without Alt-text exist.
- Selected Page (settings or dashboard) is correctly underlined on load.
- Altly Logo appears in header.

### Development Changes
- General linting using prettier.
- Updated app package version to 1.1.5
- Updated plugin version to match
- General QoL changes, by reusing code where possible. Simplifying calls and loops.
- Changed some wording to be clearer, ex. "License Key is not valid. Please try another key." instead of "Value is not correct"
- Adds [hash] to bundled JS/CSS names so that updated plugins don't cache UI information
- Updates `analyze_image_on_upload` to check credits before running.
- Refactors PHP Classes to re-use data like "license-key"
- Updates Helpers->queueImages to take number of available credits into account so Bulk Generate doesn't use more than the available credits.
- Updates `UserRoute.php` to pull available Credits from Supabase and not WP MySQL.
- Moves `callExternalApi` to Helpers to be used in multiple routes.